### PR TITLE
Updated KRadioButton 'value' prop 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
  
   [#482]: https://github.com/learningequality/kolibri-design-system/pull/482
 
-    - [#484]
+- [#484]
   - **Description:** Updated KRadioButton 'value' prop to 'buttonValue'
   - **Products impact:** Updated API
   - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/379

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,14 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
     - [#484]
   - **Description:** Updated KRadioButton 'value' prop to 'buttonValue'
-  - **Products impact:** Script Enhancement
+  - **Products impact:** Updated API
   - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/379
   - **Components:** KRadioButton
   - **Breaking:** Yes
   - **Impacts a11y:** 
-  - **Guidance:** -KRadioButton 'value' prop is deprecated. Please use the 'buttonValue' prop instead.
+  - **Guidance:** KRadioButton 'value' prop is deprecated. Please use the 'buttonValue' prop instead.
  
-  [#482]: https://github.com/learningequality/kolibri-design-system/pull/484
+  [#484]: https://github.com/learningequality/kolibri-design-system/pull/484
 
 - [#464]
   - **Description:** Add KTextTruncator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
  
   [#482]: https://github.com/learningequality/kolibri-design-system/pull/482
 
+    - [#484]
+  - **Description:** Updated KRadioButton 'value' prop to 'buttonValue'
+  - **Products impact:** Script Enhancement
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/379
+  - **Components:** KRadioButton
+  - **Breaking:** Yes
+  - **Impacts a11y:** 
+  - **Guidance:** -KRadioButton 'value' prop is deprecated. Please use the 'buttonValue' prop instead.
+ 
+  [#482]: https://github.com/learningequality/kolibri-design-system/pull/484
+
 - [#464]
   - **Description:** Add KTextTruncator
   - **Products impact:** new API

--- a/docs/pages/kradiobutton.vue
+++ b/docs/pages/kradiobutton.vue
@@ -10,23 +10,23 @@
         <KRadioButton
           v-model="exampleValue"
           label="Option A"
-          value="val-a"
+          buttonValue="val-a"
         />
         <KRadioButton
           v-model="exampleValue"
           label="Option B"
-          value="val-b"
+          buttonValue="val-b"
         />
         <KRadioButton
           v-model="exampleValue"
           label="Option C"
           description="This one is special!"
-          value="val-c"
+          buttonValue="val-c"
         />
         <KRadioButton
           v-model="exampleValue"
           label="Truncated label. Adjusting your browser window size to see this in action."
-          value="val-d"
+          buttonValue="val-d"
           truncateLabel
         />
         <p>

--- a/lib/KRadioButton.vue
+++ b/lib/KRadioButton.vue
@@ -13,7 +13,7 @@
           type="radio"
           class="k-radio-button-input"
           :checked="isChecked"
-          :value="value"
+          :buttonValue="buttonValue"
           :disabled="disabled"
           :autofocus="autofocus"
           @click.stop="toggleCheck"
@@ -103,7 +103,7 @@
       /**
        * Unique value that will be assigned to `v-model` data when this radio button is selected
        */
-      value: {
+      buttonValue: {
         type: [String, Number, Boolean],
         required: true,
       },
@@ -141,7 +141,7 @@
     }),
     computed: {
       isChecked() {
-        return this.value.toString() === this.currentValue.toString();
+        return this.buttonValue.toString() === this.currentValue.toString();
       },
       id() {
         return `${this._uid}`;
@@ -189,9 +189,9 @@
         this.$emit('change', this.isChecked, event);
 
         /**
-         * Used to set `value` to `v-model` when checked
+         * Used to set `buttonValue` to `v-model` when checked
          */
-        this.$emit('input', this.value);
+        this.$emit('input', this.buttonValue);
       },
       blur() {
         this.active = false;


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Updated the KRadioButton 'value' prop to 'buttonValue' and configured it to avoid confusion regarding API decision.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #379 

### Before/after screenshots
Before
![image](https://github.com/learningequality/kolibri-design-system/assets/95405559/8ef9fb6a-53b4-4275-a8c7-1ce3ef6d1be7)
After
![image](https://github.com/learningequality/kolibri-design-system/assets/95405559/3e96a314-8b7f-4ca9-bb4f-8cea15593cd7)

## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#484]
  - **Description:** Updated KRadioButton 'value' prop to 'buttonValue'
  - **Products impact:** Updated API
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/379
  - **Components:** KRadioButton
  - **Breaking:** Yes
  - **Impacts a11y:** 
  - **Guidance:** KRadioButton 'value' prop is deprecated. Please use the 'buttonValue' prop instead.

  [#484]: https://github.com/learningequality/kolibri-design-system/pull/484


